### PR TITLE
Article 2: Adding Messaging to OpenClaw (Telegram → Slack)

### DIFF
--- a/data/blog/2-messaging-setup.mdx
+++ b/data/blog/2-messaging-setup.mdx
@@ -7,7 +7,7 @@ summary: "My journey through Telegram, WhatsApp, Discord, and finally Slack. Why
 images: ['https://images.unsplash.com/photo-1523280197092-71fbf8563799?q=80&w=2320&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D']
 ---
 
-![Messaging platforms](/api/placeholder.png)
+![Messaging platforms](https://images.unsplash.com/photo-1523280197092-71fbf8563799?q=80&w=2320&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)
 
 ## TL;DR
 

--- a/data/blog/2-messaging-setup.mdx
+++ b/data/blog/2-messaging-setup.mdx
@@ -1,0 +1,533 @@
+---
+title: 'Adding Messaging to OpenClaw: Telegram, WhatsApp, Discord, and Why I Chose Slack'
+date: '2026-03-31'
+lastmod: '2026-03-31'
+tags: ['openclaw', 'automation', 'messaging', 'tech']
+summary: "My journey through Telegram, WhatsApp, Discord, and finally Slack. Why I tested four different messaging platforms, the technical and personal friction points, and why Slack became the right choice for my OpenClaw setup."
+images: ['https://images.unsplash.com/photo-1611532736579-6b16e2b50449?auto=format&fit=crop&w=1161&q=80']
+---
+
+![Messaging platforms](/api/placeholder.png)
+
+## TL;DR
+
+After burning 2 weeks testing **Telegram** (blocked in Pakistan, VPN hell), **WhatsApp** (personal number discomfort, talking to myself felt weird), and **Discord** (bot went stale overnight), I landed on **Slack**.
+
+Why? It's where I already work. The setup requires effort, but it's rock-solid reliable, persistent, and doesn't disappear on you like Discord bots do.
+
+If you're integrating OpenClaw with messaging and already use Slack for work, stop reading guides for other platforms. Go with Slack.
+
+---
+
+## Why Messaging Matters for OpenClaw
+
+Before diving into the options, let me explain why this mattered to me.
+
+OpenClaw running 24/7 on Hostinger is great, but **I needed a way to talk to it without SSH-ing in every time.** I wanted:
+
+- **Instant notifications** when tasks complete
+- **A conversational interface** from anywhere (phone, desktop, work)
+- **Persistent history** of what I've asked the agent to do
+- **Reliability** — no dropouts, no stale bots disappearing
+
+Messaging apps felt like the natural choice. Most people live in their messaging apps anyway. Why not just... talk to OpenClaw from there?
+
+Sounds simple. It wasn't. This is where the real story begins.
+
+---
+
+## Telegram: The "Universal Bot Platform" That Isn't
+
+My first instinct: **Telegram.** Everyone uses it. Bots are built in. It's designed for this.
+
+### Why Telegram Seemed Perfect
+
+Telegram marketing itself as a bot developer's dream:
+- **Native bot API** — purpose-built for this use case
+- **No approval process** — create a bot in seconds with BotFather
+- **Lightweight** — minimal bandwidth, perfect for always-on agents
+- **Global** — works everywhere (or so I thought)
+
+### The Reality: Geopolitics Enters the Chat
+
+I'm in **Pakistan.** Telegram is **banned in Pakistan.**
+
+Not throttled. Not filtered. **Banned.** The protocol is blocked at ISP level.
+
+My options:
+1. Use a VPN 24/7 (terrible for battery, obvious in logs)
+2. Route OpenClaw traffic through a VPN proxy (adds latency, single point of failure)
+3. Give up
+
+I went with option 2 for a day. Set up WireGuard on the Hostinger VPS, tunneled Telegram traffic through it. It worked, but the friction was absurd:
+
+- Every bot message had a 2-3 second latency spike
+- VPN tunnel would occasionally drop (3-5 times daily)
+- My ISP's firewall was aggressively blocking anything that smelled like Telegram
+
+### The Setup (For Those Who Tried)
+
+If you're not in a blocked region, Telegram setup is trivial:
+
+```bash
+# 1. Talk to BotFather on Telegram
+# Command: /newbot
+# Name: OpenClaw Agent
+# Username: @openclaw_agent_bot (must be unique)
+
+# 2. BotFather gives you a token
+export TELEGRAM_BOT_TOKEN="your_token_here"
+
+# 3. Install a Telegram client library
+npm install telegraf
+
+# 4. Create your bot
+const { Telegraf } = require('telegraf');
+const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
+
+bot.start((ctx) => ctx.reply('Hello! I am OpenClaw.'));
+bot.on('text', async (ctx) => {
+  const response = await callOpenClawAgent(ctx.message.text);
+  ctx.reply(response);
+});
+
+bot.launch();
+```
+
+That's it. 20 lines of code and you have a working bot.
+
+**But then reality hits.**
+
+### Why It Didn't Work
+
+1. **Geographic blocking** — Telegram is blocked in Pakistan at the ISP level. VPN routing adds constant friction and latency.
+
+2. **No rich formatting** — Telegram bots can send text and basic buttons, but if you want actual UI elements, you're hacking it together with inline keyboards.
+
+3. **Rate limits bite hard** — Telegram has strict rate limiting. After a certain number of messages per minute, you get temporarily blocked. Not ideal when an agent is running lots of tasks.
+
+4. **No native file persistence** — If you want to store conversation history, files, or agent state, Telegram doesn't help. You're building your own database anyway.
+
+After 3 days of this, with latency spikes and occasional disconnects, I decided: **This isn't worth it.** Geographic restrictions are a showstopper.
+
+---
+
+## WhatsApp: The Personal Number Problem
+
+Plan B: **WhatsApp.** It's the most-used messaging app globally. Surely this is the obvious choice?
+
+### The Official Bot API
+
+Meta (WhatsApp's parent) does offer a **WhatsApp Business API** for bots. It's the "official" way to integrate.
+
+Setup:
+- Register a business account
+- Get a phone number (business or personal)
+- Integrate via the official API
+- Messages cost money (~$0.05 per outbound message)
+
+### The Friction Point
+
+I read the docs. They kept saying "**use a dedicated business phone number.**"
+
+The implication: You don't use your personal number. You get a separate number for the bot. But here's the catch — you're still **receiving messages from the bot on that same number**, which means:
+
+1. You're getting push notifications as if a real person is texting you
+2. You're talking to yourself
+3. It feels... lonely? Weird?
+
+### Why I Didn't Go Further
+
+It's not a technical problem. It's a UX problem.
+
+WhatsApp is built around **person-to-person communication.** When you open WhatsApp, you're expecting to see chats from friends, family, colleagues.
+
+A chat with a bot feels out of place. And when that bot is **your own agent**, talking to yourself through an official Meta API?
+
+The friction is psychological. Every time I'd open WhatsApp to message my OpenClaw bot, I'd feel the weirdness. It's not terrible, but it's a constant micro-friction.
+
+Plus: **The messaging costs add up.** At $0.05 per outbound message, and my agent sending 10-50 messages per day? That's $150-700/month just in notification costs.
+
+**Not happening.**
+
+### What Surprised Me
+
+I expected WhatsApp to be technically complex. It wasn't. The official API is well-documented. The problem wasn't code — it was context. WhatsApp is a **personal communication tool**, and trying to use it for agent interaction felt fundamentally wrong.
+
+---
+
+## Discord: The Bot That Went Stale
+
+Discord seemed like the obvious choice. It's designed for communities and automation. Bots are first-class citizens.
+
+### Why Discord Looked Promising
+
+- **Mature bot ecosystem** — thousands of existing Discord bots
+- **Easy to set up** — Discord Developer Portal, minimal friction
+- **Rich UI** — buttons, embeds, reactions, threads — you can build real interfaces
+- **No costs** — bots are free to run (you just host them)
+- **Communities feel natural** — Discord servers feel like the right place for an agent
+
+### The Setup
+
+Discord bot setup is clean:
+
+```bash
+# 1. Create a Discord server (or use existing)
+# 2. Go to Discord Developer Portal: discord.com/developers
+# 3. Create a new application
+# 4. Create a Bot user
+# 5. Get your bot token
+
+export DISCORD_BOT_TOKEN="your_token_here"
+
+# 6. Install discord.py or discord.js
+npm install discord.js
+
+# 7. Code your bot
+const { Client, GatewayIntentBits } = require('discord.js');
+const client = new Client({ intents: [GatewayIntentBits.DirectMessages] });
+
+client.on('messageCreate', async (message) => {
+  if (message.author.bot) return;
+  
+  const response = await callOpenClawAgent(message.content);
+  message.reply(response);
+});
+
+client.login(process.env.DISCORD_BOT_TOKEN);
+```
+
+I had this running in 30 minutes. The bot worked perfectly. I could send it tasks, it responded, it was actually cool to use.
+
+### The Reliability Problem
+
+And then I didn't use it for 24 hours.
+
+When I came back, the bot wasn't responding.
+
+I checked the logs. The bot process was still running. Discord showed it as "online." But messages weren't being received.
+
+**The bot had gone stale.**
+
+This isn't unique to my setup. It's a known Discord issue: if your bot hasn't received messages in a while, the connection silently drops. The bot thinks it's connected. Discord thinks it's connected. But nothing actually transmits.
+
+### Troubleshooting Hell
+
+I dug into Discord.js docs. The solution: **implement a heartbeat/ping system.** Your bot should periodically send ping messages to itself to keep the connection alive.
+
+```javascript
+// Keep-alive ping system
+setInterval(() => {
+  client.user.setActivity('Waiting for tasks...', { type: 'WATCHING' });
+}, 5 * 60 * 1000); // Every 5 minutes
+```
+
+Did that work? Partially. Sometimes the connection would still drop, but less frequently.
+
+The root cause: **Discord's bot API wasn't designed for long-lived, stateful connections.** It's designed for bots that do discrete things (play music, moderate chat, run games), not autonomous agents that sit idle waiting for commands.
+
+### Why This Killed Discord
+
+After 2-3 days of intermittent staleouts, I realized: **I can't trust this.**
+
+If my OpenClaw agent is sitting on Hostinger, running 24/7, and Discord randomly drops the connection, then I'm not actually always-on. I'm only available when I remember to check on the bot.
+
+For a 24/7 agent, reliability is non-negotiable. Discord bots are not reliable for this use case.
+
+---
+
+## Slack: The Unexpected Winner
+
+After the Discord failure, I was ready to give up on messaging entirely. Just stick with SSH and cron jobs.
+
+Then I realized: **I spend 8 hours a day on Slack for work.**
+
+Why not just... use what I already have?
+
+### The Setup Effort
+
+Slack integration requires more work than the other platforms:
+
+1. **Create a workspace** (unless you want to pollute your work Slack)
+2. **Create an app** in the Slack App Directory
+3. **Configure bot tokens and permissions**
+4. **Write code to handle incoming messages**
+5. **Deploy your bot** somewhere always-on
+
+It's not hard, just more steps than "talk to BotFather."
+
+```bash
+# 1. Go to api.slack.com/apps
+# 2. Create New App
+# 3. Configure scopes:
+#    - chat:write
+#    - chat:read
+#    - im:read
+#    - im:history
+#    - app_mentions:read
+#    - commands
+
+# 4. Get your bot token and signing secret
+export SLACK_BOT_TOKEN="xoxb-your-token"
+export SLACK_SIGNING_SECRET="your-secret"
+
+# 5. Install dependencies
+npm install @slack/bolt
+
+# 6. Create your bot
+const { App } = require('@slack/bolt');
+
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN,
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+});
+
+app.message(async ({ message, say }) => {
+  const response = await callOpenClawAgent(message.text);
+  say(response);
+});
+
+(async () => {
+  await app.start(process.env.PORT || 3000);
+  console.log('⚡️ Bolt app is running!');
+})();
+```
+
+That's the basic bot. You'd deploy this to your Hostinger VPS (or a cheap Heroku-like service), point Slack's webhook at it, and you're done.
+
+### The Unreasonable Reliability
+
+Here's what surprised me: **Slack just works.**
+
+I've had the bot running for 3 weeks now. Zero dropouts. Zero stale connections. Messages are instant (< 100ms latency).
+
+And unlike Discord, if the bot goes down for an hour (maintenance, restart, whatever), users just see a delayed response. The bot doesn't disappear. Slack re-queues the message.
+
+### The Natural Fit
+
+The real win: **It's where I already work.**
+
+My team uses Slack for:
+- Daily standups
+- Code reviews
+- Random discussions
+- Notifications from CI/CD
+
+Adding OpenClaw to Slack felt like adding one more tool to an ecosystem I already live in. No new app. No new habit.
+
+### Slack's Limitations (So You Know)
+
+For honesty, here's what Slack doesn't let you do:
+- **Rich UI components** — Discord has buttons and embeds. Slack is mostly text + some formatting.
+- **File uploads from the bot** — Slack bots can send messages, but uploading files is restricted (you can work around it, but it's friction).
+- **Direct calls to API** — some things require Slack's web client, not the bot API
+- **Message threading** — Slack threads are awkward compared to Discord
+
+But none of these mattered for what I needed: **send task results to a DM, get acknowledgment, move on.**
+
+### The Cost
+
+Slack's free tier lets you host a bot. If you go pro, Slack costs money ($8+/user/month for a workspace).
+
+I created a separate "personal automation" workspace just for my OpenClaw bot, so I didn't have to pay. Slack's free tier is generous enough.
+
+---
+
+## The Comparison Table
+
+Here's the full breakdown:
+
+| Platform | Telegram | WhatsApp | Discord | Slack |
+|----------|----------|----------|---------|-------|
+| **Setup time** | 20 min | 30 min | 30 min | 60 min |
+| **Code complexity** | Simple | Medium | Simple | Medium |
+| **Geographic restrictions** | Blocked in Pakistan 🚫 | None | None | None |
+| **Reliability** | Good (if VPN works) | Excellent | Poor (stale bots) | Excellent |
+| **Message costs** | Free | $0.05/msg | Free | Free |
+| **Psychological friction** | VPN latency | Talking to self | None | None |
+| **Rich UI** | Basic buttons | Buttons | Embeds, buttons | Text + formatting |
+| **24/7 persistence** | Requires VPN | Works | Stale after 24h | Rock solid |
+| **Natural fit** | No | No | Gaming/communities | Work environments |
+
+---
+
+## What I Learned
+
+1. **Geography matters.** You can't build a product for Pakistan that relies on Telegram. Geographic restrictions are showstoppers.
+
+2. **Platform psychology is real.** WhatsApp isn't broken. It's just the wrong tool for talking to a bot. You can force it, but you'll feel the friction every time.
+
+3. **Discord is great, but not for long-lived agents.** It's a social platform first, an automation platform second. Bots that sit idle get abandoned by Discord's infrastructure.
+
+4. **Slack's richness isn't in UI — it's in integration.** Slack wins because it's where you already work, not because it has the fanciest buttons.
+
+5. **Choose tools you already live in.** If you're checking Slack 100 times a day for work, adding your agent there costs zero additional context switches. That's worth more than perfect APIs or fancy interfaces.
+
+6. **Reliability is non-negotiable for 24/7 agents.** A 99% reliable bot is not 99% useful. It's 30% useful, because you can't trust it for important tasks.
+
+---
+
+## The Slack Setup (Full Recipe)
+
+If you want to replicate what I did, here's the complete setup:
+
+### 1. Create or Choose a Workspace
+
+Either:
+- Use your existing work Slack (if you can), or
+- Create a free personal workspace at slack.com
+
+### 2. Create the Slack App
+
+```bash
+# Visit: https://api.slack.com/apps
+# Click "Create New App"
+# Choose "From scratch"
+# Name: "OpenClaw Agent"
+# Pick a workspace
+```
+
+### 3. Configure Scopes
+
+In your app settings:
+
+```
+OAuth & Permissions → Scopes:
+
+Bot Token Scopes:
+- chat:write
+- im:read
+- im:history
+- app_mentions:read
+- commands
+```
+
+### 4. Configure Event Subscriptions
+
+```
+Event Subscriptions → Subscribe to bot events:
+- message.im (Direct messages to the bot)
+- app_mention (When someone mentions your bot)
+```
+
+### 5. Get Your Tokens
+
+```
+OAuth & Permissions:
+- Copy: "Bot User OAuth Token" (starts with xoxb-)
+- Copy: "Signing Secret" (under "App Credentials")
+```
+
+### 6. Deploy Your Bot
+
+Create a simple Node.js bot on your Hostinger VPS:
+
+```javascript
+// bot.js
+const { App } = require('@slack/bolt');
+
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN,
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+});
+
+// Handle DMs and mentions
+app.message(async ({ message, say, client }) => {
+  try {
+    // Skip bot messages
+    if (message.bot_id) return;
+    
+    // Call your OpenClaw agent
+    const response = await callOpenClawAgent(message.text);
+    
+    // Send response
+    await say(response);
+  } catch (error) {
+    await say(`Error: ${error.message}`);
+  }
+});
+
+// Health check endpoint
+app.event('app_mention', async ({ event, say }) => {
+  await say(`Hi <@${event.user}>! I'm alive.`);
+});
+
+(async () => {
+  await app.start(process.env.PORT || 3000);
+  console.log('⚡️ Slack bot is running!');
+})();
+```
+
+### 7. Configure the Webhook
+
+In Slack App settings:
+
+```
+Event Subscriptions → Request URL:
+https://your-openclaw-vps.com:3000/slack/events
+```
+
+Slack will send a challenge request. Your bot needs to respond to it (the `@slack/bolt` library handles this automatically).
+
+### 8. Install to Your Workspace
+
+```
+Install App → Install to Workspace
+```
+
+Allow the permissions Slack asks for.
+
+### 9. Test It
+
+Go to your Slack workspace, find the bot (it'll show up in your sidebar), and send it a message.
+
+Done! Your OpenClaw agent is now reachable from Slack.
+
+---
+
+## Why This Worked (And Why It's Worth the Effort)
+
+After testing four platforms, Slack won not because it's the easiest, but because it's the right tool for the right context.
+
+- **You already live there.** Every notification is one less app to check.
+- **It's reliable.** Three weeks of 24/7 uptime with zero message loss.
+- **Setup effort is justified.** 60 minutes of work for months of reliable automation.
+- **It integrates naturally.** Your agent sits in your work environment where it belongs.
+
+If you're building something like OpenClaw and already use Slack for work, this choice is obvious. Don't spend a week comparing options. Go with what you already know works.
+
+---
+
+## What's Next?
+
+With messaging solved (finally), I moved on to:
+- **Token optimization** — Slack messages are cheaper than Discord/Telegram, but still add up
+- **Context window management** — How to structure agent conversations without burning API budgets
+- **Persistent state** — Remembering tasks across sessions
+- **Scheduled workflows** — Cron jobs, heartbeats, calendars
+
+But that's the next story. For now, I've got a 24/7 agent that's reachable from anywhere, doesn't drop connections, and feels natural to use.
+
+Mission accomplished.
+
+---
+
+## TL;DR (Redux)
+
+**Don't use Telegram** if you're in a blocked region.
+
+**Don't use WhatsApp** unless you want to accept message costs and weird psychology.
+
+**Don't use Discord** for long-lived agents (bot stale-outs are a dealbreaker).
+
+**Use Slack** if you already work there. It's worth the extra setup effort.
+
+---
+
+## Links
+
+- [Slack Bolt Documentation](https://slack.dev/bolt-js/)
+- [Slack API Reference](https://api.slack.com/)
+- [OpenClaw Documentation](https://docs.openclaw.ai)
+- [Slack App Directory](https://api.slack.com/apps)

--- a/data/blog/2-messaging-setup.mdx
+++ b/data/blog/2-messaging-setup.mdx
@@ -4,7 +4,7 @@ date: '2026-03-31'
 lastmod: '2026-03-31'
 tags: ['openclaw', 'automation', 'messaging', 'tech']
 summary: "My journey through Telegram, WhatsApp, Discord, and finally Slack. Why I tested four different messaging platforms, the technical and personal friction points, and why Slack became the right choice for my OpenClaw setup."
-images: ['https://images.unsplash.com/photo-1611532736579-6b16e2b50449?auto=format&fit=crop&w=1161&q=80']
+images: ['https://images.unsplash.com/photo-1523280197092-71fbf8563799?q=80&w=2320&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D']
 ---
 
 ![Messaging platforms](/api/placeholder.png)

--- a/data/blog/2-messaging-setup.mdx
+++ b/data/blog/2-messaging-setup.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Adding Messaging to OpenClaw: Telegram, WhatsApp, Discord, and Why I Chose Slack'
+title: 'OpenClaw Chat: Why Slack is better than Telegram, WhatsApp, Discord'
 date: '2026-03-31'
 lastmod: '2026-03-31'
-tags: ['openclaw', 'automation', 'messaging', 'tech']
+tags: ['openclaw', 'tech', 'AI']
 summary: "My journey through Telegram, WhatsApp, Discord, and finally Slack. Why I tested four different messaging platforms, the technical and personal friction points, and why Slack became the right choice for my OpenClaw setup."
 images: ['https://images.unsplash.com/photo-1523280197092-71fbf8563799?q=80&w=2320&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D']
 ---


### PR DESCRIPTION
## Adding Messaging to OpenClaw: Telegram, WhatsApp, Discord, and Why I Chose Slack

Complete evaluation of messaging platforms for OpenClaw setup journey.

### What's Covered
- **Telegram**: Pakistan geographic blocking, VPN friction, latency issues
- **WhatsApp**: Personal number discomfort, talking-to-self UX problem  
- **Discord**: Bot setup successful, but stale after 24h (reliability killer)
- **Slack**: Natural fit (already use for work), took effort but perfect balance

### Content Details
- **Word count**: 2,879 words (technical + personal narrative)
- **Format**: .mdx with code examples and platform comparison table
- **Tone**: Honest about failures, directly matching article #1 style

### Part of Series
- Part 1: Choosing the right VPS (LightSail vs Hostinger)
- Part 2: **This** — Messaging setup journey
- Part 3: Context window optimization (Opus → Haiku)